### PR TITLE
Allow to initialize write data

### DIFF
--- a/src/precice/SolverInterface.cpp
+++ b/src/precice/SolverInterface.cpp
@@ -31,6 +31,13 @@ double SolverInterface::initialize()
   return _impl->initialize();
 }
 
+void SolverInterface::initializeWriteScalarData(
+      int    dataID,
+      int    valueIndex,
+      double value) {
+  _impl->initializeWriteScalarData(dataID, valueIndex, value);
+}
+
 void SolverInterface::initializeData()
 {
   _impl->initializeData();

--- a/src/precice/SolverInterface.hpp
+++ b/src/precice/SolverInterface.hpp
@@ -94,6 +94,25 @@ public:
   double initialize();
 
   /**
+   * @brief Writes scalar data to a vertex
+   *
+   * This function writes a value of a specified vertex to a dataID. The data will be used as initial data
+   *
+   * @param[in] dataID ID to write to.
+   * @param[in] valueIndex Index of the vertex.
+   * @param[in] value the value to write.
+   *
+   * @pre initialize() has been called successfully.
+   * @pre initializeData() has not yet been called.
+   * @pre advance() has not yet been called.
+   * @pre finalize() has not yet been called.
+   */
+  void initializeWriteScalarData(
+      int    dataID,
+      int    valueIndex,
+      double value);
+
+  /**
    * @brief Initializes coupling data.
    *
    * The starting values for coupling data are zero by default.

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -27,6 +27,13 @@ mesh::PtrData DataContext::providedData()
   return _providedData;
 }
 
+time::PtrWaveform DataContext::providedWaveform()
+{
+  PRECICE_TRACE();
+  PRECICE_ASSERT(_providedWaveform);
+  return _providedWaveform;
+}
+
 std::string DataContext::getDataName() const
 {
   PRECICE_TRACE();
@@ -136,24 +143,33 @@ const MappingContext DataContext::mappingContext() const
   return _mappingContext;
 }
 
-void DataContext::initializeProvidedWaveform()
+void DataContext::initializeProvidedWaveform(bool initializedData)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(not hasMapping());
+  if(initializedData) {
+    _hasInitializedData = 1;
+  }
   initializeWaveform(_providedData, _providedWaveform);
 }
 
-void DataContext::initializeFromWaveform()
+void DataContext::initializeFromWaveform(bool initializedData)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(hasMapping());
+  if(initializedData) {
+    _hasInitializedData = 1;
+  }
   initializeWaveform(_fromData, _fromWaveform);
 }
 
-void DataContext::initializeToWaveform()
+void DataContext::initializeToWaveform(bool initializedData)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(hasMapping());
+  if(initializedData) {
+    _hasInitializedData = 1;
+  }
   initializeWaveform(_toData, _toWaveform);
 }
 
@@ -213,7 +229,7 @@ Eigen::VectorXd DataContext::sampleAt(double dt, int timeWindows)
   PRECICE_ASSERT(_providedWaveform->numberOfData() == _providedData->values().size(),
                  _providedWaveform->numberOfData(), _providedData->values().size());
   int order = 1;
-  return _providedWaveform->sample(dt, timeWindows, order);
+  return _providedWaveform->sample(dt, timeWindows + _hasInitializedData, order);
 }
 
 void DataContext::initializeWaveform(mesh::PtrData initializingData, time::PtrWaveform initializedWaveform)

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -23,6 +23,8 @@ public:
 
   mesh::PtrData providedData();
 
+  time::PtrWaveform providedWaveform();
+
   std::string getDataName() const;
 
   int getProvidedDataID() const;
@@ -54,11 +56,11 @@ public:
   const MappingContext mappingContext() const;
 
   // for updating waveforms after communication
-  void initializeProvidedWaveform();
+  void initializeProvidedWaveform(bool initializedData = false);
 
-  void initializeFromWaveform();
+  void initializeFromWaveform(bool initializedData = false);
 
-  void initializeToWaveform();
+  void initializeToWaveform(bool initializedData = false);
 
   // for mapping waveforms
   void moveWaveformSampleToData(int sampleID);
@@ -104,6 +106,9 @@ private:
   mesh::PtrData _toData;
 
   MappingContext _mappingContext;
+
+  //  set to 1, if there is initialized data for this waveform that can be used for interpolation
+  int _hasInitializedData = 0;
 
   // helper function for initializing waveforms from given data
   void initializeWaveform(mesh::PtrData initializingData, time::PtrWaveform initializedWaveform);

--- a/src/precice/impl/SolverInterfaceImpl.hpp
+++ b/src/precice/impl/SolverInterfaceImpl.hpp
@@ -121,6 +121,25 @@ public:
   double initialize();
 
   /**
+   * @brief Writes scalar data to a vertex
+   *
+   * This function writes a value of a specified vertex to a dataID. The data will be used as initial data
+   *
+   * @param[in] dataID ID to write to.
+   * @param[in] valueIndex Index of the vertex.
+   * @param[in] value the value to write.
+   *
+   * @pre initialize() has been called successfully.
+   * @pre initializeData() has not yet been called.
+   * @pre advance() has not yet been called.
+   * @pre finalize() has not yet been called.
+   */
+  void initializeWriteScalarData(
+      int    dataID,
+      int    valueIndex,
+      double value);
+
+  /**
    * @brief Sets the sofar written data as initial value for the coupling scheme.
    *
    * Erases the written data afterwards.
@@ -744,7 +763,7 @@ private:
   void clearMappings(utils::ptr_vector<MappingContext> contexts);
 
   /// Initializes waveforms of write data contexts before mapping.
-  void initializeWrittenWaveforms();
+  void initializeWrittenWaveforms(bool initializedData = false);
 
   /// Prepare for write mapping
   void storeWriteDataInWrittenWaveform();

--- a/src/precice/tests/SerialTests.cpp
+++ b/src/precice/tests/SerialTests.cpp
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithWaveformSampling)
   typedef double (*DataFunction)(double, int);
 
   DataFunction dataOneFunction = [](double t, int idx) -> double {
-    return (double) (t + idx);
+    return (double) (2 + t + idx);
   };
   DataFunction dataTwoFunction = [](double t, int idx) -> double {
     return (double) (10 + t + idx);
@@ -368,6 +368,11 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithWaveformSampling)
     BOOST_TEST(readDataID == 2);
   }
 
+  for (int i = 0; i < n_vertices; i++) {
+    writeData[i] = writeFunction(time - dt, i);
+    precice.initializeWriteScalarData(writeDataID, vertexIDs[i], writeData[i]);
+  }
+
   if (precice.isActionRequired(precice::constants::actionWriteInitialData())) {
     for (int i = 0; i < n_vertices; i++) {
       writeData[i] = writeFunction(time, i);
@@ -391,23 +396,11 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithWaveformSampling)
         precice.readScalarData(readDataID, vertexIDs[i], currentDt, readData[i]);
         BOOST_TEST(readData[i] == readFunction(readTime, i));
         precice.readScalarData(readDataID, vertexIDs[i], currentDt / 4, readData[i]);
-        if (timestep == 0) { // in the first window, we only have one sample of data. Therefore constant interpolation
-          BOOST_TEST(readData[i] == readFunction(readTime, i));
-        } else { // in the following windows we have two samples of data. Therefore linear interpolation
-          BOOST_TEST(readData[i] == readFunction(readTime - currentDt * 3 / 4, i));
-        }
+        BOOST_TEST(readData[i] == readFunction(readTime - currentDt * 3 / 4, i));
         precice.readScalarData(readDataID, vertexIDs[i], currentDt / 2, readData[i]);
-        if (timestep == 0) { // in the first window, we only have one sample of data. Therefore constant interpolation
-          BOOST_TEST(readData[i] == readFunction(readTime, i));
-        } else { // in the following windows we have two samples of data. Therefore linear interpolation
-          BOOST_TEST(readData[i] == readFunction(readTime - currentDt / 2, i));
-        }
+        BOOST_TEST(readData[i] == readFunction(readTime - currentDt / 2, i));
         precice.readScalarData(readDataID, vertexIDs[i], currentDt * 3 / 4, readData[i]);
-        if (timestep == 0) { // in the first window, we only have one sample of data. Therefore constant interpolation
-          BOOST_TEST(readData[i] == readFunction(readTime, i));
-        } else { // in the following windows we have two samples of data. Therefore linear interpolation
-          BOOST_TEST(readData[i] == readFunction(readTime - currentDt / 4, i));
-        }
+        BOOST_TEST(readData[i] == readFunction(readTime - currentDt / 4, i));
       }
     }
 
@@ -445,7 +438,7 @@ BOOST_AUTO_TEST_CASE(testExplicitReadWriteScalarDataWithWaveformSubcycling)
   typedef double (*DataFunction)(double, int);
 
   DataFunction dataOneFunction = [](double t, int idx) -> double {
-    return (double) (t + idx);
+    return (double) (2 + t + idx);
   };
   DataFunction dataTwoFunction = [](double t, int idx) -> double {
     return (double) (10 + t + idx);

--- a/src/time/Waveform.cpp
+++ b/src/time/Waveform.cpp
@@ -42,6 +42,13 @@ void Waveform::storeAt(const Eigen::VectorXd data, int columnID)
   this->_timeWindows.col(columnID) = data;
 }
 
+void Waveform::storeScalarAt(const double value, int columnID, int valueIndex)
+{
+  PRECICE_ASSERT(_timeWindows.cols() > columnID, numberOfSamples(), columnID);
+  PRECICE_ASSERT(valueIndex < numberOfData(), valueIndex, numberOfData());
+  this->_timeWindows.col(columnID)(valueIndex) = value;
+}
+
 Eigen::VectorXd Waveform::sample(double dt, int timeWindows, int order)
 {
   PRECICE_ASSERT(dt >= 0, "Sampling outside of valid range!");

--- a/src/time/Waveform.hpp
+++ b/src/time/Waveform.hpp
@@ -38,6 +38,14 @@ public:
   void storeAt(const Eigen::VectorXd data, int columnID);
 
   /**
+   * @brief Updates entry in _timeWindows corresponding to a given column ID and data ID with given scalar value
+   * @param value scalar value at data ID for this time window
+   * @param columnID ID of column to be updated
+   * @param valueIndex ID of value to be updated
+   */
+  void storeScalarAt(const double value, int columnID, int valueIndex);
+
+  /**
    * @brief Called, when moving to the next time window. All entries in _timeWindows are shifted. The new entry is initialized as the value from the last window (= constant extrapolation)
    * @param timeWindows number of samples that are valid and may be used for extrapolation. Usually number of past time windows.
    */


### PR DESCRIPTION
## Main changes of this PR

Add API function `initializeWriteScalarData(writeData, vertexIDs, dataID)` which allows to set value of Waveform at starting time of the simulation. This is an optional API call.

## Motivation and additional information

Currently we can only use constant interpolation in the first window, since only one data point is available from `writeScalarData`. This data is associated with the end of the window. Offering an API call `initializeWriteScalarData` which must be called before `initializeData` allows us to provide data associated with the beginning of the first window. Together with the data provided via `writeScalarData` this allows linear interpolation already in the first window.

Note that for the second and following windows the data from the previous window will be used to define the linear interpolation. Therefore, the API call `initializeWriteScalarData` should only change the behavior in the first window.

## Todos

- [ ] merge #1 
- [ ] extend tests to this new API function and make sure that linear interpolation in first window is supported.

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)